### PR TITLE
Include the license in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include requirements.txt
 include regexorder/templates.json
+include LICENSE


### PR DESCRIPTION
The license requires that all copies of the code include the license text. This patch makes sure the sdists include it.